### PR TITLE
switch to the swift collective's libwebp.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
 *.trace
+/.vscode

--- a/Package.resolved
+++ b/Package.resolved
@@ -19,12 +19,12 @@
       }
     },
     {
-      "identity" : "swift-libwebp",
+      "identity" : "libwebp",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/stackotter/swift-libwebp",
+      "location" : "https://github.com/the-swift-collective/libwebp",
       "state" : {
-        "revision" : "61dc3787c764022ad2f5ab4f9994a569afe86f9f",
-        "version" : "0.2.0"
+        "revision" : "5f745a17b9a5c2a4283f17c2cde4517610ab5f99",
+        "version" : "1.4.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/the-swift-collective/libpng", from: "1.6.45"),
         .package(url: "https://github.com/stackotter/jpeg", from: "1.0.2"),
-        .package(url: "https://github.com/stackotter/swift-libwebp", from: "0.2.0"),
+        .package(url: "https://github.com/the-swift-collective/libwebp", from: "1.4.1"),
     ],
     targets: [
         .target(
@@ -22,7 +22,7 @@ let package = Package(
             dependencies: [
                 .product(name: "LibPNG", package: "libpng"),
                 .product(name: "JPEG", package: "jpeg"),
-                .product(name: "WebP", package: "swift-libwebp"),
+                .product(name: "WebP", package: "libwebp"),
             ]
         ),
         .testTarget(

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A cross-platform Swift library for working with various image file formats.
 
 - `.png`: Using [pnggroup/libpng](https://github.com/pnggroup/libpng) (via [the-swift-collective/libpng](https://github.com/the-swift-collective/libpng))
 - `.jpeg`: Using [tayloraswift/jpeg](https://github.com/tayloraswift/jpeg)
-- `.webp`: Using [webmproject/libwebp](https://github.com/webmproject/libwebp) (via [stackotter/swift-libwebp](https://github.com/stackotter/swift-libwebp))
+- `.webp`: Using [webmproject/libwebp](https://github.com/webmproject/libwebp) (via [the-swift-collective/libwebp](https://github.com/the-swift-collective/libpng))
 
 In future I'd like to add support for bitmaps, gifs, and heic files.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A cross-platform Swift library for working with various image file formats.
 
 - `.png`: Using [pnggroup/libpng](https://github.com/pnggroup/libpng) (via [the-swift-collective/libpng](https://github.com/the-swift-collective/libpng))
 - `.jpeg`: Using [tayloraswift/jpeg](https://github.com/tayloraswift/jpeg)
-- `.webp`: Using [webmproject/libwebp](https://github.com/webmproject/libwebp) (via [the-swift-collective/libwebp](https://github.com/the-swift-collective/libpng))
+- `.webp`: Using [webmproject/libwebp](https://github.com/webmproject/libwebp) (via [the-swift-collective/libwebp](https://github.com/the-swift-collective/libwebp))
 
 In future I'd like to add support for bitmaps, gifs, and heic files.
 


### PR DESCRIPTION
Part of our efforts to condense and streamline all the various C/C++ dependencies under one central repository, this is important because Swift makes it all too easy to have 30 different `zlib` libraries for example, which leads to a headache of duplicated symbols and what not.