### PR TITLE
Implement naive linear downscaling

### DIFF
--- a/Sources/ImageFormats/Image+Operations.swift
+++ b/Sources/ImageFormats/Image+Operations.swift
@@ -20,6 +20,45 @@ extension Image where Pixel: InterpolatableConvertible {
         return Self(width: targetWidth, height: targetHeight, pixels: pixels)
     }
 
+    /// Linearly downscales the image using naive pixel averaging (no weighting).
+    public func linearlyDownscale(
+        toWidth targetWidth: Int,
+        height targetHeight: Int
+    ) -> Self {
+        precondition(targetWidth <= width)
+        precondition(targetHeight <= height)
+
+        func computeSourcePosition(x: Int, y: Int) -> (Int, Int) {
+            let sourceX = Double(x) * Double(width) / Double(targetWidth)
+            let sourceY = Double(y) * Double(height) / Double(targetHeight)
+            let originX = Int(sourceX.rounded(.towardZero))
+            let originY = Int(sourceY.rounded(.towardZero))
+            return (
+                min(originX, width),
+                min(originY, height)
+            )
+        }
+
+        var pixels: [Pixel] = []
+        for y in 0..<targetHeight {
+            for x in 0..<targetWidth {
+                let (sourceX, sourceY) = computeSourcePosition(x: x, y: y)
+                let (endSourceX, endSourceY) = computeSourcePosition(x: x + 1, y: y + 1)
+                let bucketWidth = endSourceX - sourceX
+                let bucketHeight = endSourceY - sourceY
+                var accumulated = Pixel.InterpolatableRepresentation.zero
+                for innerY in sourceY..<endSourceY {
+                    for innerX in sourceX..<endSourceX {
+                        accumulated += self[row: innerY][column: innerX].interpolatable
+                    }
+                }
+                accumulated = accumulated * (1 / Double(bucketWidth * bucketHeight))
+                pixels.append(Pixel(from: accumulated))
+            }
+        }
+        return Self(width: targetWidth, height: targetHeight, pixels: pixels)
+    }
+
     func lanczosInterpolate(atX x: Double, y: Double, radius: Int) -> Pixel {
         let xRange = lanczosRange(around: x, radius: radius)
         let yRange = lanczosRange(around: y, radius: radius)

--- a/Sources/ImageFormats/Interpolatable.swift
+++ b/Sources/ImageFormats/Interpolatable.swift
@@ -11,6 +11,13 @@ extension Interpolatable {
     }
 }
 
+extension Interpolatable {
+    /// Division by a scalar.
+    public static func / (_ value: Self, _ scalar: Double) -> Self {
+        value * (1 / scalar)
+    }
+}
+
 /// Interpolatable types are trivially convertible to interpolatable types.
 extension Interpolatable {
     public init(from interpolatable: Self) {


### PR DESCRIPTION
This algorithm resamples images to lower resolutions by bucketing pixels and averaging them. In future we should implement weighting so that downscaling by factors less than 2 works nicely, but for my usecase I only need downscaling for roughly integer factors so this good enough.